### PR TITLE
Ref/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ install:
   # - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib ipywidgets
   # - git clone https://github.com/simpeg/simpeg.git
   # - cd simpeg; git checkout dev; git pull; python setup.py build_ext --inplace; cd ..
-  - export PATH=$PWD/em_examples:$PATH
-  - export PYTHONPATH=$PWD/em_examples:$PYTHONPATH
+  - export PATH=$PWD:$PATH
+  - export PYTHONPATH=$PWD:$PYTHONPATH
 
 # Run test
 script:

--- a/notebooks/maxwell1_fundamentals/InductionRLcircuit.ipynb
+++ b/notebooks/maxwell1_fundamentals/InductionRLcircuit.ipynb
@@ -11,14 +11,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "# IMPORT PACKAGES\n",
-    "import InductionLoop as IND\n",
+    "import em_examples.InductionLoop as IND\n",
     "from ipywidgets import interact, FloatSlider, FloatText"
    ]
   },
@@ -245,32 +245,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
    "version": "2.7.12"
-  },
-  "widgets": {
-   "state": {
-    "27f0b5106d104cabb3242e02722c8823": {
-     "views": [
-      {
-       "cell_index": 8
-      }
-     ]
-    },
-    "739b8ec3cd1340d0a479a40309c0128c": {
-     "views": [
-      {
-       "cell_index": 6
-      }
-     ]
-    },
-    "8f07388caf2e4ac8a47ac7c4665e5879": {
-     "views": [
-      {
-       "cell_index": 4
-      }
-     ]
-    }
-   },
-   "version": "1.2.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- All notebooks should use imports of the form `import em_examples.module` 
- I have updated the .travis.yml so that only the root directory is added to the path, thus enforcing that we use imports of the form `import em_examples` cc @sgkang 